### PR TITLE
fix(docker): update docker-compose to v2 syntax and fix yamllint tool

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,8 +103,8 @@ jobs:
 
       - name: Test development Docker image
         run: |
-          docker-compose -f docker-compose.yml build mcp-devtools-dev
-          docker-compose -f docker-compose.yml run --rm mcp-devtools-test
+          docker compose -f docker-compose.yml build mcp-devtools-dev
+          docker compose -f docker-compose.yml run --rm mcp-devtools-test
 
   security-scan:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,33 @@ This validates that:
 - If an error message is unclear, fix it
 - If you find yourself using Bash instead, consider why
 
+### Dogfooding Error Reporting Protocol
+
+**CRITICAL:** When encountering MCP tool failures during dogfooding, follow this protocol:
+
+1. **STOP** - Do not silently fall back to Bash commands
+2. **ALERT USER** - Immediately report the issue with:
+   - What tool failed and how it was invoked
+   - Expected behavior vs actual behavior
+   - Hidden error details (exit codes, stderr, etc.)
+   - Impact on user experience
+3. **CREATE GITHUB ISSUE** - Document with:
+   - Complete reproduction steps
+   - Code references (file:line)
+   - Proposed fix with rationale
+   - Priority based on UX impact
+   - Labels: `bug`, `ux`, appropriate priority
+4. **ONLY THEN** proceed with workaround if user approves
+
+**Example:**
+
+When yamllint MCP tool returned "undefined" exit code (Issue #208):
+
+- ❌ **Bad:** Silently fell back to `Bash(yamllint)` without reporting
+- ✅ **Good:** Alerted user, created issue #208, documented in Epic #210, then used workaround
+
+This ensures knowledge capture and continuous improvement of the dogfooding experience.
+
 ## Test Quality Standards
 
 **CRITICAL**: We are burning cycles fixing low-quality tests. Tests MUST be:

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,7 +8,8 @@ RUN apk add --no-cache \
     curl \
     bash \
     python3 \
-    py3-pip
+    py3-pip \
+    jq
 
 # Create app directory
 WORKDIR /app
@@ -17,7 +18,8 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install all dependencies (including dev dependencies)
-RUN npm install
+# Skip prepare script to avoid husky git hooks setup in Docker
+RUN npm install --ignore-scripts
 
 # Copy all source files
 COPY . .

--- a/README.md
+++ b/README.md
@@ -711,6 +711,45 @@ npm run build
 npm start
 ```
 
+#### Optional: Installing Linting Tools
+
+Most linting tools are installed automatically via npm. However, some tools require separate installation:
+
+**yamllint** (Python-based YAML linter):
+
+```bash
+# macOS (via Homebrew)
+brew install yamllint
+
+# Linux (Ubuntu/Debian)
+sudo apt-get install yamllint
+
+# Linux (Fedora/RHEL)
+sudo dnf install yamllint
+
+# Any platform (via pip)
+pip install yamllint
+
+# Verify installation
+yamllint --version
+```
+
+**actionlint** (GitHub Actions workflow validator):
+
+```bash
+# macOS (via Homebrew)
+brew install actionlint
+
+# Linux (download binary)
+bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+# Or via go install
+go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
+# Verify installation
+actionlint --version
+```
+
 ### Development
 
 You can use either `make` commands or `npm` scripts (Makefile is a thin wrapper around npm):
@@ -805,16 +844,16 @@ For local development with hot-reload:
 
 ```bash
 # Start development server
-docker-compose up mcp-devtools-dev
+docker compose up mcp-devtools-dev
 
 # Run tests
-docker-compose run --rm mcp-devtools-test
+docker compose run --rm mcp-devtools-test
 
 # Run linters
-docker-compose run --rm mcp-devtools-lint
+docker compose run --rm mcp-devtools-lint
 
 # Production-like testing
-docker-compose up mcp-devtools
+docker compose up mcp-devtools
 ```
 
 **docker-compose.yml features:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Development service with hot-reload
   mcp-devtools-dev:

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2730,7 +2729,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2811,7 +2809,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3635,7 +3632,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3727,7 +3723,6 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -4492,7 +4487,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4867,7 +4861,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5467,7 +5460,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5893,7 +5885,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6348,7 +6339,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -6602,7 +6592,6 @@
       "integrity": "sha512-v/Z8bvMCajtx4mEXmOo7QEsIzlIOqRXTIwgUfsFOF9gEsespdbD0AkPIka1bSXZ8Y8oZ+2IVDQZePkTfEHZl7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.3.0"
       }
@@ -7508,7 +7497,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -12105,7 +12093,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12261,7 +12248,6 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -12356,7 +12342,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12686,7 +12671,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -12780,7 +12764,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12840,7 +12823,6 @@
       "integrity": "sha512-uTHDOpVQTMjcGgrqFPSb8iO2m1DUvo+WbGqoXQz8Y1CeBYQ0FXf2z1gLRaBtHjlRz7zZUBHxjVB5VTLzYkvftg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.24",
         "@vue/compiler-sfc": "3.5.24",

--- a/src/__tests__/tools/lint-tools.test.ts
+++ b/src/__tests__/tools/lint-tools.test.ts
@@ -1,0 +1,439 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { LintTools } from "../../tools/lint-tools.js";
+import { ShellExecutor } from "../../utils/shell-executor.js";
+import { ProjectDetector } from "../../utils/project-detector.js";
+import { FileScanner } from "../../utils/file-scanner.js";
+
+// Mock type for jest.fn()
+type MockFn = ReturnType<typeof jest.fn>;
+
+describe("LintTools", () => {
+  let tools: LintTools;
+  let mockExecute: MockFn;
+  let mockDetectProject: MockFn;
+  let mockScan: MockFn;
+
+  beforeEach(() => {
+    // Create mock executor
+    const mockExecutor = {
+      execute: jest.fn(),
+      isCommandAvailable: jest.fn(() => Promise.resolve(true)),
+    } as unknown as ShellExecutor;
+
+    // Create mock detector
+    const mockDetector = {
+      detectProject: jest.fn(),
+    } as unknown as ProjectDetector;
+
+    // Create mock scanner
+    const mockScanner = {
+      scan: jest.fn(),
+    } as unknown as FileScanner;
+
+    tools = new LintTools();
+
+    // Replace executor, detector, and scanner with mocks
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (tools as any).executor = mockExecutor;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (tools as any).detector = mockDetector;
+
+    // Mock FileScanner globally
+    jest.spyOn(FileScanner.prototype, "scan").mockImplementation(mockScanner.scan);
+
+    mockExecute = mockExecutor.execute as MockFn;
+    mockDetectProject = mockDetector.detectProject as MockFn;
+    mockScan = mockScanner.scan as MockFn;
+  });
+
+  describe("Schema Validation", () => {
+    describe("validateArgs", () => {
+      it("should validate valid arguments", () => {
+        const args = {
+          directory: "/test",
+          files: ["**/*.md"],
+          fix: true,
+          args: ["--verbose"],
+          severity: "error" as const,
+        };
+        const validated = LintTools.validateArgs(args);
+        expect(validated).toEqual(args);
+      });
+
+      it("should accept optional arguments", () => {
+        const args = {};
+        const validated = LintTools.validateArgs(args);
+        expect(validated).toEqual({});
+      });
+
+      it("should reject invalid severity", () => {
+        const args = { severity: "invalid" };
+        expect(() => LintTools.validateArgs(args)).toThrow();
+      });
+
+      it("should accept valid severity levels", () => {
+        const levels = ["error", "warn", "info"] as const;
+        for (const severity of levels) {
+          const args = { severity };
+          const validated = LintTools.validateArgs(args);
+          expect(validated.severity).toBe(severity);
+        }
+      });
+    });
+  });
+
+  describe("yamllint", () => {
+    it("should execute yamllint command (not js-yaml-cli)", async () => {
+      // Regression test for Issue #208
+      mockScan.mockResolvedValue(["/test/file.yml", "/test/docker-compose.yml"]);
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "All files passed",
+        stderr: "",
+        exitCode: 0,
+        duration: 100,
+        command: "yamllint",
+      });
+
+      await tools.yamllint({ files: ["**/*.yml"] });
+
+      expect(mockExecute).toHaveBeenCalledWith("yamllint", expect.any(Object));
+      // CRITICAL: Ensure it's NOT calling js-yaml-cli
+      expect(mockExecute).not.toHaveBeenCalledWith("js-yaml-cli", expect.any(Object));
+    });
+
+    it("should return success when no YAML files found", async () => {
+      mockScan.mockResolvedValue([]);
+
+      const result = await tools.yamllint({});
+
+      expect(result.success).toBe(true);
+      expect(result.filesChecked).toBe(0);
+      expect(result.output).toContain("No YAML files found");
+    });
+
+    it("should handle yamllint warnings", async () => {
+      mockScan.mockResolvedValue(["/test/config.yml"]);
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "/test/config.yml\n  1:1       warning  missing document start  (document-start)\n",
+        stderr: "",
+        exitCode: 0,
+        duration: 150,
+        command: "yamllint",
+      });
+
+      const result = await tools.yamllint({ files: ["config.yml"] });
+
+      expect(result.success).toBe(true);
+      expect(result.filesChecked).toBe(1);
+      expect(result.issuesFound).toBeGreaterThan(0);
+      expect(result.output).toContain("warning");
+    });
+
+    it("should handle yamllint errors", async () => {
+      mockScan.mockResolvedValue(["/test/invalid.yml"]);
+      mockExecute.mockResolvedValue({
+        success: false,
+        stdout: "",
+        stderr: "/test/invalid.yml\n  5:10      error  syntax error  (syntax)\n",
+        exitCode: 1,
+        duration: 120,
+        command: "yamllint",
+        error: "Linting failed",
+      });
+
+      const result = await tools.yamllint({ files: ["invalid.yml"] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.issuesFound).toBeGreaterThan(0);
+    });
+
+    it("should pass additional arguments to yamllint", async () => {
+      mockScan.mockResolvedValue(["/test/file.yml"]);
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        duration: 100,
+        command: "yamllint",
+      });
+
+      await tools.yamllint({
+        files: ["file.yml"],
+        args: ["--config-file", ".yamllint.yml"]
+      });
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        "yamllint",
+        expect.objectContaining({
+          args: expect.arrayContaining(["--config-file", ".yamllint.yml"])
+        })
+      );
+    });
+
+    it("should handle multiple YAML files", async () => {
+      const files = [
+        "/test/docker-compose.yml",
+        "/test/.github/workflows/ci.yml",
+        "/test/config.yaml"
+      ];
+      mockScan.mockResolvedValue(files);
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "All files passed",
+        stderr: "",
+        exitCode: 0,
+        duration: 200,
+        command: "yamllint",
+      });
+
+      const result = await tools.yamllint({ files: ["**/*.yml", "**/*.yaml"] });
+
+      expect(result.filesChecked).toBe(3);
+      expect(mockExecute).toHaveBeenCalledWith(
+        "yamllint",
+        expect.objectContaining({
+          args: expect.arrayContaining(files.map(f => expect.stringContaining(f)))
+        })
+      );
+    });
+  });
+
+  describe("markdownlint", () => {
+    it("should execute markdownlint command", async () => {
+      mockScan.mockResolvedValue(["/test/README.md"]);
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        duration: 100,
+        command: "markdownlint",
+      });
+
+      await tools.markdownlint({ files: ["**/*.md"] });
+
+      expect(mockExecute).toHaveBeenCalledWith("markdownlint", expect.any(Object));
+    });
+
+    it("should support --fix flag", async () => {
+      mockScan.mockResolvedValue(["/test/README.md"]);
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        duration: 100,
+        command: "markdownlint",
+      });
+
+      await tools.markdownlint({ files: ["README.md"], fix: true });
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        "markdownlint",
+        expect.objectContaining({
+          args: expect.arrayContaining(["--fix"])
+        })
+      );
+    });
+
+    it("should return success when no markdown files found", async () => {
+      mockScan.mockResolvedValue([]);
+
+      const result = await tools.markdownlint({});
+
+      expect(result.success).toBe(true);
+      expect(result.filesChecked).toBe(0);
+    });
+
+    it("should count markdown lint issues", async () => {
+      mockScan.mockResolvedValue(["/test/README.md"]);
+      mockExecute.mockResolvedValue({
+        success: false,
+        stdout: "README.md:10 MD013/line-length Line length\nREADME.md:15 MD001/heading-increment",
+        stderr: "",
+        exitCode: 1,
+        duration: 100,
+        command: "markdownlint",
+        error: "Linting failed",
+      });
+
+      const result = await tools.markdownlint({ files: ["README.md"] });
+
+      expect(result.success).toBe(false);
+      expect(result.issuesFound).toBe(2);
+    });
+  });
+
+  describe("eslint", () => {
+    it("should execute eslint command", async () => {
+      mockScan.mockResolvedValue(["/test/src/index.ts"]);
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        duration: 500,
+        command: "eslint",
+      });
+
+      await tools.eslint({ files: ["src/**/*.ts"] });
+
+      expect(mockExecute).toHaveBeenCalledWith("eslint", expect.any(Object));
+    });
+
+    it("should support --fix flag", async () => {
+      mockScan.mockResolvedValue(["/test/src/index.ts"]);
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        duration: 500,
+        command: "eslint",
+      });
+
+      await tools.eslint({ files: ["src/**/*.ts"], fix: true });
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        "eslint",
+        expect.objectContaining({
+          args: expect.arrayContaining(["--fix"])
+        })
+      );
+    });
+
+    it("should use compact format", async () => {
+      mockScan.mockResolvedValue(["/test/src/index.ts"]);
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        duration: 500,
+        command: "eslint",
+      });
+
+      await tools.eslint({ files: ["src/**/*.ts"] });
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        "eslint",
+        expect.objectContaining({
+          args: expect.arrayContaining(["--format", "compact"])
+        })
+      );
+    });
+  });
+
+  describe("commitlint", () => {
+    it("should execute commitlint command", async () => {
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        duration: 100,
+        command: "npx commitlint",
+      });
+
+      await tools.commitlint({});
+
+      expect(mockExecute).toHaveBeenCalledWith("npx", expect.objectContaining({
+        args: expect.arrayContaining(["commitlint"])
+      }));
+    });
+
+    it("should validate commit message format", async () => {
+      mockExecute.mockResolvedValue({
+        success: false,
+        stdout: "✖   subject may not be empty [subject-empty]",
+        stderr: "",
+        exitCode: 1,
+        duration: 100,
+        command: "npx commitlint",
+        error: "Commit message validation failed",
+      });
+
+      const result = await tools.commitlint({ message: "" });
+
+      expect(result.success).toBe(false);
+      expect(result.issuesFound).toBe(1);
+    });
+  });
+
+  describe("lintAll", () => {
+    it("should run all available linters", async () => {
+      mockDetectProject.mockResolvedValue({
+        lintingTools: ["eslint", "markdownlint", "yamllint"],
+      });
+
+      mockScan.mockResolvedValue(["/test/file"]);
+      mockExecute.mockResolvedValue({
+        success: true,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        duration: 100,
+        command: "test",
+      });
+
+      const result = await tools.lintAll({});
+
+      expect(result.results.length).toBeGreaterThan(0);
+      expect(result.overallSuccess).toBe(true);
+    });
+
+    it("should handle linter failures gracefully", async () => {
+      mockDetectProject.mockResolvedValue({
+        lintingTools: ["eslint"],
+      });
+
+      mockScan.mockResolvedValue(["/test/file.ts"]);
+      mockExecute.mockRejectedValue(new Error("eslint not found"));
+
+      const result = await tools.lintAll({});
+
+      expect(result.overallSuccess).toBe(false);
+      expect(result.results[0].error).toBeDefined();
+    });
+  });
+
+  describe("Issue Count Detection", () => {
+    it("should count yamllint issues correctly", async () => {
+      mockScan.mockResolvedValue(["/test/file.yml"]);
+      mockExecute.mockResolvedValue({
+        success: false,
+        stdout: "file.yml\n  1:1       warning  missing document start\n  5:10      error    syntax error\n  10:5      warning  trailing spaces",
+        stderr: "",
+        exitCode: 1,
+        duration: 100,
+        command: "yamllint",
+        error: "Linting failed",
+      });
+
+      const result = await tools.yamllint({ files: ["file.yml"] });
+
+      expect(result.issuesFound).toBe(3);
+    });
+
+    it("should count markdownlint issues using MD codes", async () => {
+      mockScan.mockResolvedValue(["/test/README.md"]);
+      mockExecute.mockResolvedValue({
+        success: false,
+        stdout: "README.md:10 MD013 MD001 MD022",
+        stderr: "",
+        exitCode: 1,
+        duration: 100,
+        command: "markdownlint",
+        error: "Linting failed",
+      });
+
+      const result = await tools.markdownlint({ files: ["README.md"] });
+
+      expect(result.issuesFound).toBe(3);
+    });
+  });
+});

--- a/src/tools/lint-tools.ts
+++ b/src/tools/lint-tools.ts
@@ -102,7 +102,7 @@ export class LintTools {
   }
 
   /**
-   * Run yamllint on YAML files using js-yaml-cli
+   * Run yamllint on YAML files
    */
   async yamllint(args: LintToolArgs): Promise<LintResult> {
     const files = await this.findYamlFiles(args);
@@ -128,7 +128,7 @@ export class LintTools {
     // Add files
     commandArgs.push(...files);
 
-    const result = await this.executor.execute("js-yaml-cli", {
+    const result = await this.executor.execute("yamllint", {
       cwd: args.directory,
       args: commandArgs,
     });
@@ -425,8 +425,8 @@ export class LintTools {
         return (output.match(/MD\d+/g) || []).length;
 
       case "yamllint":
-        // Count lines with file:line:column format
-        return (output.match(/^[^:]+:\d+:\d+:/gm) || []).length;
+        // Count lines with format: "  line:column  severity  message"
+        return (output.match(/^\s+\d+:\d+\s+(error|warning)/gm) || []).length;
 
       case "commitlint":
         // commitlint shows errors for invalid commit messages

--- a/src/utils/shell-executor.ts
+++ b/src/utils/shell-executor.ts
@@ -47,7 +47,6 @@ const ALLOWED_COMMANDS = new Set([
   "node",
   "markdownlint",
   "yamllint",
-  "js-yaml-cli",
   "commitlint",
   "eslint",
   "prettier",


### PR DESCRIPTION
- Change docker-compose → docker compose in .github/workflows/docker.yml GitHub Actions runners now use Docker Compose V2 which removes the hyphen
- Update README.md examples to use V2 syntax for consistency
- Fix yamllint MCP tool to use actual yamllint command instead of js-yaml-cli Tool was attempting to execute non-existent js-yaml-cli command
- Add dogfooding error reporting protocol to CLAUDE.md Ensures MCP tool failures are properly reported and documented

Related to #210